### PR TITLE
Fixed CRC

### DIFF
--- a/examples/rpi.rs
+++ b/examples/rpi.rs
@@ -1,7 +1,7 @@
 //! Raspberry Pi demo
 
 extern crate linux_embedded_hal as hal;
-extern crate ms5611;
+extern crate ms5611_spi as ms5611;
 
 use hal::spidev::{self, SpidevOptions};
 use hal::sysfs_gpio::Direction;


### PR DESCRIPTION
Fixed CRC by replacing the CRC with 0 during the calculation (see AN520 for reference).
Replaced test case with my coefficients, that lead to a failure with the old faulty implementation.