### PR TITLE
Update to newer ehal, make delay-dependent calls explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ keywords = ["pressure", "sensor", "spi", "no-std", "hal"]
 repository = "https://github.com/Arkaleks/ms5611"
 
 [dependencies]
-embedded-hal = "0.2"
+embedded-hal = "0.2.3"
 
 [dev-dependencies]
 embedded-hal-mock = "0.5"
 linux-embedded-hal = "0.2.2"
+
+

--- a/examples/rpi.rs
+++ b/examples/rpi.rs
@@ -16,15 +16,16 @@ fn main() {
         .build();
     spi.configure(&options).unwrap();
 
+    let mut delay_source = Delay;
     let ncs = Pin::new(25);
     ncs.export().unwrap();
     while !ncs.is_exported() {}
     ncs.set_direction(Direction::Out).unwrap();
     ncs.set_value(1).unwrap();
 
-    let mut ms5611 = Ms5611::new(spi, ncs, Delay).unwrap();
+    let mut ms5611 = Ms5611::new(spi, ncs, &mut delay_source).unwrap();
     let sample = ms5611
-        .get_second_order_sample(Oversampling::OS_2048)
+        .get_second_order_sample(Oversampling::OS_2048, &mut delay_source)
         .unwrap();
     println!("{:?}", sample);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,9 +337,11 @@ mod tests {
     use super::*;
 
     struct Pin;
-    impl hal::digital::OutputPin for Pin {
-        fn set_low(&mut self) {}
-        fn set_high(&mut self) {}
+
+    impl hal::digital::v2::OutputPin for Pin {
+	type Error = u32;
+        fn set_low(&mut self) -> Result<(), Self::Error> { Ok(()) }
+        fn set_high(&mut self) -> Result<(), Self::Error> { Ok(()) }
     }
 
     #[test]
@@ -399,13 +401,13 @@ mod tests {
 
         let spi = SpiMock::new(&expectations);
         let pin = Pin;
-        let delay = MockNoop::new();
-        let mut ms5611 = Ms5611::new(spi, pin, delay).unwrap();
+        let mut delay_source = MockNoop::new();
+        let mut ms5611 = Ms5611::new(spi, pin, &mut delay_source).unwrap();
         let sample1 = ms5611
-            .get_compensated_sample(Oversampling::OS_2048)
+            .get_compensated_sample(Oversampling::OS_2048, &mut delay_source)
             .unwrap();
         let sample2 = ms5611
-            .get_second_order_sample(Oversampling::OS_2048)
+            .get_second_order_sample(Oversampling::OS_2048, &mut delay_source)
             .unwrap();
 
         assert_eq!(


### PR DESCRIPTION
My goal is to use this driver in a bare metal cortex-m embedded app (specifically [stm32h7xx-hal](https://crates.io/crates/stm32h7xx-hal) based). This requires updating to a newer embedded-hal version. 
